### PR TITLE
fix: Request timeout for gthread workers

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -21,16 +21,9 @@ jobs:
          - macos-13
          # Not testing Windows, because tests need Unix-only fcntl, grp, pwd, etc.
         python-version:
-         # CPython <= 3.7 is EoL since 2023-06-27
-         - "3.7"
-         - "3.8"
-         - "3.9"
          - "3.10"
          - "3.11"
          - "3.12"
-         # PyPy <= 3.8 is EoL since 2023-06-16
-         - "pypy-3.9"
-         - "pypy-3.10"
         include:
          # Note: potentially "universal2" release
          # https://github.com/actions/runner-images/issues/9741

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-  py{37,38,39,310,311,312,py3},
+  py{310,311,312,py3},
   lint,
   docs-lint,
   pycodestyle,


### PR DESCRIPTION
`gthread` workers don't implement request timeouts. This PR implements a crude request timeout that is similar to `sync` workers. 


When a request times out that worker plans exit by setting `self.alive` to false. This stops the poller and gives 30 second (default) grace timeout to complete ongoing requests.

Accepted faults: A request that is `accept`ed but not read from yet will fail. The code to make this work makes it extra complex and I'd prefer trading that edge case off for simpler implementation.