### PR TITLE
Revert "gthread: only read sockets when they are readable"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,7 @@ This is a fork of gunicorn with the following changes:
 
 1. Request timeout implementation for `gthread` - https://github.com/frappe/gunicorn/pull/1 (upstream doesn't have any, we NEED this.)
 2. Higher timeout for `selector` - https://github.com/frappe/gunicorn/pull/2 (This is a small optional performance improvement)
+3. https://github.com/benoitc/gunicorn/pull/2918 is reverted to avoid connection resets while draining or restarting a worker. 
 
 Note to anyone upgrading/adding changes:
 - Pull upstream changes

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -40,15 +40,12 @@ class TConn:
 
         self.timeout = None
         self.parser = None
-        self.initialized = False
 
         # set the socket to non blocking
         self.sock.setblocking(False)
 
     def init(self):
-        self.initialized = True
         self.sock.setblocking(True)
-
         if self.parser is None:
             # wrap the socket if needed
             if self.cfg.is_ssl:
@@ -129,27 +126,23 @@ class ThreadWorker(base.Worker):
             conn = TConn(self.cfg, sock, client, server)
 
             self.nr_conns += 1
-            # wait until socket is readable
-            with self._lock:
-                self.poller.register(conn.sock, selectors.EVENT_READ,
-                                     partial(self.on_client_socket_readable, conn))
-        except OSError as e:
+            # enqueue the job
+            self.enqueue_req(conn)
+        except EnvironmentError as e:
             if e.errno not in (errno.EAGAIN, errno.ECONNABORTED,
                                errno.EWOULDBLOCK):
                 raise
 
-    def on_client_socket_readable(self, conn, client):
+    def reuse_connection(self, conn, client):
         with self._lock:
             # unregister the client from the poller
             self.poller.unregister(client)
-
-            if conn.initialized:
-                # remove the connection from keepalive
-                try:
-                    self._keep.remove(conn)
-                except ValueError:
-                    # race condition
-                    return
+            # remove the connection from keepalive
+            try:
+                self._keep.remove(conn)
+            except ValueError:
+                # race condition
+                return
 
         # submit the connection to a worker
         self.enqueue_req(conn)
@@ -283,7 +276,7 @@ class ThreadWorker(base.Worker):
 
                     # add the socket to the event loop
                     self.poller.register(conn.sock, selectors.EVENT_READ,
-                                         partial(self.on_client_socket_readable, conn))
+                                         partial(self.reuse_connection, conn))
             else:
                 self.nr_conns -= 1
                 conn.close()


### PR DESCRIPTION
This reverts commit 0ebb73aa240f0ecffe3e0922d54cfece19f5bfed.


---

This fixes https://github.com/benoitc/gunicorn/issues/3038 which was introduced by a fix for a deadlock when gunicorn is directly used as web server, we always have nginx proxy. So we can live without that fix. 